### PR TITLE
修复stats_overview查询中时间区间没有正常生效的问题

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -156,16 +156,16 @@ pub fn stats_overview(time_range: Option<String>) -> AppResult<OverviewStats> {
     let ts_lower = compute_time_lower(&time_range);
     let ts_upper = compute_time_upper(&time_range);
 
-    let mut where_clauses = Vec::new();
-    let mut params = Vec::new();
+    let mut where_clauses: Vec<String> = Vec::new();
+    let mut params: Vec<rusqlite::types::Value> = Vec::new();
 
     if let Some(lower) = ts_lower {
         where_clauses.push("last_visited_time >= ?".to_string());
-        params.push(lower);
+        params.push(lower.into());
     }
     if let Some(upper) = ts_upper {
         where_clauses.push("last_visited_time <= ?".to_string());
-        params.push(upper);
+        params.push(upper.into());
     }
 
     let where_sql = if where_clauses.is_empty() {

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ async function fetchStats() {
       timeRange = `${startTs}-${endTs}`;
     }
 
-    const stats = await invoke('stats_overview', { time_range: timeRange });
+    const stats = await invoke('stats_overview', { timeRange: timeRange });
     renderKpis(stats);
   } catch (e) {
     console.error('获取统计失败:', e);


### PR DESCRIPTION
This pull request makes small but important improvements to parameter naming consistency and type safety in the statistics overview functionality. The most significant changes are:

**Parameter naming consistency:**

* Changed the parameter name from `time_range` to `timeRange` in the JavaScript call to `invoke`, fixed the bug in stats_overview.

**Type safety improvements:**

* Explicitly specified the types of `where_clauses` and `params` in the Rust `stats_overview` function, and ensured the correct conversion of values when pushing to `params` for better type safety and clarity.

Fixes #28 