### PR TITLE
新增top站点数量可配置

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -2,6 +2,11 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use once_cell::sync::OnceCell;
+use std::sync::Mutex;
+
+// AppConfig的全局内存缓存，以避免频繁的磁盘读取
+static GLOBAL_CONFIG: OnceCell<Mutex<AppConfig>> = OnceCell::new();
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct AppConfig {
@@ -40,16 +45,24 @@ impl AppConfig {
     }
 
     pub fn load() -> Result<Self> {
-        let config_path = Self::config_file_path()?;
-
-        if !config_path.exists() {
-            let default_config = Self::default();
-            default_config.save()?;
-            return Ok(default_config);
+        if let Some(m) = GLOBAL_CONFIG.get() {
+            let cfg = m.lock().unwrap();
+            return Ok(cfg.clone());
         }
 
-        let content = fs::read_to_string(&config_path)?;
-        let config: Self = serde_json::from_str(&content)?;
+        let config_path = Self::config_file_path()?;
+
+        let config = if !config_path.exists() {
+            let default_config = Self::default();
+            let _ = serde_json::to_string_pretty(&default_config)?;
+            default_config.save()?;
+            default_config
+        } else {
+            let content = fs::read_to_string(&config_path)?;
+            let config: Self = serde_json::from_str(&content)?;
+            config
+        };
+        let _ = GLOBAL_CONFIG.set(Mutex::new(config.clone()));
         Ok(config)
     }
 
@@ -57,6 +70,14 @@ impl AppConfig {
         let config_path = Self::config_file_path()?;
         let content = serde_json::to_string_pretty(self)?;
         fs::write(&config_path, content)?;
+        // 更新全局内存缓存（如果存在）
+        if let Some(m) = GLOBAL_CONFIG.get() {
+            let mut g = m.lock().unwrap();
+            *g = self.clone();
+        } else {
+            let _ = GLOBAL_CONFIG.set(Mutex::new(self.clone()));
+        }
+
         Ok(())
     }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -7,7 +7,13 @@ use std::path::{Path, PathBuf};
 pub struct AppConfig {
     pub db_path: Option<String>,
     pub browser_db_path: Option<String>,
+    #[serde(default = "default_top_sites_count")]
+    pub top_sites_count: u32,
     pub last_updated: i64,
+}
+
+fn default_top_sites_count() -> u32 {
+    6
 }
 
 impl Default for AppConfig {
@@ -15,6 +21,7 @@ impl Default for AppConfig {
         Self {
             db_path: None,
             browser_db_path: None,
+            top_sites_count: 6,
             last_updated: chrono::Utc::now().timestamp(),
         }
     }
@@ -71,6 +78,16 @@ impl AppConfig {
 
     pub fn set_browser_db_path(&mut self, path: String) -> Result<()> {
         self.browser_db_path = Some(path);
+        self.last_updated = chrono::Utc::now().timestamp();
+        self.save()?;
+        Ok(())
+    }
+
+    pub fn set_top_sites_count(&mut self, count: u32) -> Result<()> {
+        if count == 0 || count > 50 {
+            return Err(anyhow::anyhow!("TOP站点数量必须在1-50之间"));
+        }
+        self.top_sites_count = count;
         self.last_updated = chrono::Utc::now().timestamp();
         self.save()?;
         Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,8 +8,8 @@ mod domain;
 
 use commands::{
     browse_browser_db_file, browse_db_file, cleanup_old_dbs, copy_browser_db_to_app, get_config,
-    list_history, open_db_directory, set_browser_db_path, set_db_path, stats_overview,
-    validate_db_path,
+    list_history, open_db_directory, set_browser_db_path, set_db_path, set_top_sites_count,
+    stats_overview, validate_db_path,
 };
 
 fn main() {
@@ -25,7 +25,8 @@ fn main() {
             copy_browser_db_to_app,
             set_browser_db_path,
             open_db_directory,
-            cleanup_old_dbs
+            cleanup_old_dbs,
+            set_top_sites_count
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/settings.html
+++ b/src/settings.html
@@ -108,6 +108,24 @@
         <p><strong>注意:</strong> 如同步失败，可在浏览器关闭时复制数据库文件，避免数据库锁定问题。</p>
       </div>
     </section>
+
+    <section class="settings-section">
+      <h2>界面设置</h2>
+      <div class="setting-item">
+        <div class="number-input-container">
+          <label for="topSitesCount">TOP站点显示数量:</label>
+          <input type="number" id="topSitesCount" min="1" max="50" value="6" />
+          <span class="unit-label">个</span>
+        </div>
+        <div class="setting-description">
+          设置统计页面中显示的TOP访问站点数量，范围：1-50个
+        </div>
+      </div>
+
+      <div class="setting-actions">
+        <button id="applyTopSitesBtn" class="btn btn-primary" disabled>应用设置</button>
+      </div>
+    </section>
   </main>
 
   <div id="messageToast" class="toast" style="display: none;">

--- a/src/style.css
+++ b/src/style.css
@@ -606,15 +606,21 @@ body {
   transform: translateY(-1px);
 }
 
+.number-input-container,
 .page-nav {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0 1rem;
-  font-size: 0.875rem;
+  font-size: 1rem;
   color: var(--text-secondary);
 }
 
+.number-input-container {
+  padding: 0 0;
+}
+
+.number-input-container input,
 .page-nav input {
   width: 70px;
   padding: 0.5rem 0.75rem;
@@ -629,6 +635,7 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
+.number-input-container input:focus,
 .page-nav input:focus {
   outline: none;
   border-color: var(--accent-primary);
@@ -637,6 +644,8 @@ body {
 }
 
 /* 隐藏数字输入框的上下箭头 */
+.number-input-container input::-webkit-outer-spin-button,
+.number-input-container input::-webkit-inner-spin-button,
 .page-nav input::-webkit-outer-spin-button,
 .page-nav input::-webkit-inner-spin-button {
   -webkit-appearance: none;
@@ -646,6 +655,10 @@ body {
 .page-nav input[type=number] {
   -moz-appearance: textfield;
   appearance: textfield;
+}
+
+.number-input-container label {
+  margin-bottom: 0 !important;
 }
 
 .details h2 {


### PR DESCRIPTION
This pull request adds a configurable setting for the number of "Top Sites" displayed in the statistics page, allowing users to set a value between 1 and 50. It introduces backend support for persisting this setting, updates the frontend UI to let users adjust it, and ensures the new value is respected in statistics queries. Additional improvements include in-memory caching of configuration to reduce disk reads and related UI/UX enhancements.

**Backend: Configuration and Persistence**
- Added a `top_sites_count` field to `AppConfig` with a default value of 6, including getter/setter methods and validation (range 1-50), and in-memory caching to minimize disk reads (`src-tauri/src/config.rs`). [[1]](diffhunk://#diff-9d9aa34713985f52282c5980cc7fc5c11ea11dc5a22fcd8f8f073bca3b24e1eeR5-R29) [[2]](diffhunk://#diff-9d9aa34713985f52282c5980cc7fc5c11ea11dc5a22fcd8f8f073bca3b24e1eeR48-R80) [[3]](diffhunk://#diff-9d9aa34713985f52282c5980cc7fc5c11ea11dc5a22fcd8f8f073bca3b24e1eeR107-R116)
- Implemented a new Tauri command `set_top_sites_count` to allow updating the "Top Sites" count from the frontend (`src-tauri/src/commands.rs`).

**Backend: Statistics Query**
- Modified the `stats_overview` function to use the configurable "Top Sites" count instead of a hardcoded limit when returning site statistics (`src-tauri/src/commands.rs`). [[1]](diffhunk://#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dccR208-R209) [[2]](diffhunk://#diff-59f7096c7cd88d5d187e749ca400716cd225f951e78eac3d0081ec6c28ce5dccL232-R235)

**Frontend: UI and User Interaction**
- Added a new section to the settings page for configuring "Top Sites" count, including input validation and a dedicated "Apply" button (`src/settings.html`, `src/settings.js`). [[1]](diffhunk://#diff-12230a30964d8e269766887dc72c950838ff40c03a31d1959002adda1e973c4eR111-R128) [[2]](diffhunk://#diff-f6437b5f2e4d199e7a66f03c9d33dc5e06f5d2edc29abc401417288a43633793L20-R23) [[3]](diffhunk://#diff-f6437b5f2e4d199e7a66f03c9d33dc5e06f5d2edc29abc401417288a43633793L83-R98) [[4]](diffhunk://#diff-f6437b5f2e4d199e7a66f03c9d33dc5e06f5d2edc29abc401417288a43633793R188-R191) [[5]](diffhunk://#diff-f6437b5f2e4d199e7a66f03c9d33dc5e06f5d2edc29abc401417288a43633793R270-R285) [[6]](diffhunk://#diff-f6437b5f2e4d199e7a66f03c9d33dc5e06f5d2edc29abc401417288a43633793R358-L330)
- Improved visual feedback for invalid input and ensured the UI reflects the current configuration value (`src/settings.js`, `src/style.css`). [[1]](diffhunk://#diff-f6437b5f2e4d199e7a66f03c9d33dc5e06f5d2edc29abc401417288a43633793R270-R285) [[2]](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R609-R623) [[3]](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R638) [[4]](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R647-R648) [[5]](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R660-R663)

**Integration**
- Registered the new Tauri command in the application entrypoint (`src-tauri/src/main.rs`). [[1]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L11-R12) [[2]](diffhunk://#diff-2f5e0a90d4195e9986f5e24928dce16b59a80a2cf30f7059b38d55bd7d1eff69L28-R29)

Fixes #41 